### PR TITLE
Fix parameter name typo

### DIFF
--- a/outrig.go
+++ b/outrig.go
@@ -297,8 +297,8 @@ func (w *Watch) setType(typ string) bool {
 	return true
 }
 
-func (w *Watch) addConfigErr(err error, invalide bool) {
-	if invalide {
+func (w *Watch) addConfigErr(err error, invalid bool) {
+	if invalid {
 		w.decl.Invalid = true
 	}
 	errCtx := ds.ErrWithContext{


### PR DESCRIPTION
## Summary
- rename `invalide` parameter to `invalid`
- correct indentation for `addConfigErr`

## Testing
- `go vet ./...` *(fails: go.work requires go >= 1.24.2)*
- `GOWORK=off go vet ./...` *(fails: missing module dependencies)*
- `GOWORK=off go test ./...` *(fails: missing module dependencies)*
