### PR TITLE
Update watch API references

### DIFF
--- a/frontend/watches/nowatchmessage.tsx
+++ b/frontend/watches/nowatchmessage.tsx
@@ -29,8 +29,9 @@ export const NoWatchesMessage: React.FC<NoWatchesMessageProps> = ({ hideTitle = 
                             <p className="text-sm text-secondary mb-2 pl-4">Push values directly from your code:</p>
                             <div className="space-y-3 pl-4">
                                 <div>
-                                    <div className="font-mono text-accent">TrackValue(name, val)</div>
-                                    <div className="text-sm text-secondary">Push any value</div>
+                                    <div className="font-mono text-accent">pusher := NewWatch(name).ForPush()</div>
+                                    <div className="font-mono text-accent">pusher.Push(val)</div>
+                                    <div className="text-sm text-secondary">Push values whenever needed</div>
                                 </div>
                             </div>
                         </div>
@@ -59,7 +60,7 @@ export const NoWatchesMessage: React.FC<NoWatchesMessageProps> = ({ hideTitle = 
                             </p>
                             <div className="space-y-3 pl-4">
                                 <div>
-                                    <div className="font-mono text-accent">WatchSync(name, lock, val)</div>
+                                    <div className="font-mono text-accent">NewWatch(name).PollSync(lock, val)</div>
                                 </div>
                             </div>
                         </div>
@@ -69,16 +70,18 @@ export const NoWatchesMessage: React.FC<NoWatchesMessageProps> = ({ hideTitle = 
                             <p className="text-sm text-secondary mb-2 pl-4">Watch atomic values directly:</p>
                             <div className="space-y-3 pl-4">
                                 <div>
-                                    <div className="font-mono text-accent">WatchAtomic(name, val)</div>
+                                    <div className="font-mono text-accent">NewWatch(name).PollAtomic(val)</div>
                                 </div>
                             </div>
                         </div>
                     </div>
 
                     <div className="mt-6 text-sm text-secondary italic">
-                        Note: Values are polled every second by default. Counter versions of these functions
-                        (TrackCounter, WatchCounterFunc, WatchCounterSync, WatchAtomicCounter) are also available for
-                        tracking numeric counters.
+                        Note: Values are polled every second by default. Add
+                        <span className="font-mono">.AsCounter()</span> before
+                        <span className="font-mono">ForPush()</span> or any
+                        <span className="font-mono">Poll*</span> method to track
+                        numeric counters.
                     </div>
                 </div>
 
@@ -88,14 +91,16 @@ export const NoWatchesMessage: React.FC<NoWatchesMessageProps> = ({ hideTitle = 
                         <code>
                             <span className="text-accent">// Track a value</span>
                             <br />
-                            outrig.TrackValue("user.profile", user)
+                            pusher := outrig.NewWatch("user.profile").ForPush()
+                            <br />
+                            pusher.Push(user)
                             <br />
                             <br />
                             <span className="text-accent">// Watch a counter that updates automatically</span>
                             <br />
                             counter := atomic.Int64{}
                             <br />
-                            outrig.WatchAtomic("requests.count", &counter)
+                            outrig.NewWatch("requests.count").PollAtomic(&counter)
                             <br />
                             <br />
                             <span className="text-accent">// Watch a value with a function</span>
@@ -109,7 +114,7 @@ export const NoWatchesMessage: React.FC<NoWatchesMessageProps> = ({ hideTitle = 
                             <br />
                             <span className="text-accent">// Watch a value with mutex protection</span>
                             <br />
-                            outrig.WatchSync("app.state", &mu, &appState)
+                            outrig.NewWatch("app.state").PollSync(&mu, &appState)
                         </code>
                     </pre>
                 </div>

--- a/frontend/watches/nowatchmessage.tsx
+++ b/frontend/watches/nowatchmessage.tsx
@@ -28,7 +28,7 @@ export const NoWatchesMessage: React.FC<NoWatchesMessageProps> = ({ hideTitle = 
                             <h4 className="font-semibold text-primary">Push Values</h4>
                             <p className="text-sm text-secondary mb-2 pl-4">Push values directly from your code:</p>
                             <div className="space-y-3 pl-4">
-                                <div>
+                                <div className="text-sm">
                                     <div className="font-mono text-accent">pusher := NewWatch(name).ForPush()</div>
                                     <div className="font-mono text-accent">pusher.Push(val)</div>
                                     <div className="text-sm text-secondary">Push values whenever needed</div>
@@ -42,7 +42,7 @@ export const NoWatchesMessage: React.FC<NoWatchesMessageProps> = ({ hideTitle = 
                                 Register funcs to be polled automatically:
                             </p>
                             <div className="space-y-3 pl-4">
-                                <div>
+                                <div className="text-sm">
                                     <div className="font-mono text-accent">NewWatch(name).PollFunc(getFn)</div>
                                     <div className="text-sm text-secondary">
                                         Poll any value w/ custom synchronization
@@ -59,7 +59,7 @@ export const NoWatchesMessage: React.FC<NoWatchesMessageProps> = ({ hideTitle = 
                                 Watch values with automatic synchronization:
                             </p>
                             <div className="space-y-3 pl-4">
-                                <div>
+                                <div className="text-sm">
                                     <div className="font-mono text-accent">NewWatch(name).PollSync(lock, val)</div>
                                 </div>
                             </div>
@@ -69,7 +69,7 @@ export const NoWatchesMessage: React.FC<NoWatchesMessageProps> = ({ hideTitle = 
                             <h4 className="font-semibold text-primary">Atomic Values</h4>
                             <p className="text-sm text-secondary mb-2 pl-4">Watch atomic values directly:</p>
                             <div className="space-y-3 pl-4">
-                                <div>
+                                <div className="text-sm">
                                     <div className="font-mono text-accent">NewWatch(name).PollAtomic(val)</div>
                                 </div>
                             </div>
@@ -77,11 +77,14 @@ export const NoWatchesMessage: React.FC<NoWatchesMessageProps> = ({ hideTitle = 
                     </div>
 
                     <div className="mt-6 text-sm text-secondary italic">
-                        Note: Values are polled every second by default. Add
-                        <span className="font-mono">.AsCounter()</span> before
-                        <span className="font-mono">ForPush()</span> or any
-                        <span className="font-mono">Poll*</span> method to track
-                        numeric counters.
+                        Note: Values are polled every second by default. <br />
+                        <a
+                            href="https://pkg.go.dev/github.com/outrigdev/outrig"
+                            target="_blank"
+                            className="text-accent hover:underline"
+                        >
+                            GoDoc Documentation
+                        </a>
                     </div>
                 </div>
 

--- a/frontend/watches/watches.tsx
+++ b/frontend/watches/watches.tsx
@@ -340,7 +340,7 @@ const AddWatchButton: React.FC<AddWatchButtonProps> = ({ model }) => {
                 isOpen={isAddWatchModalOpen}
                 onClose={() => setIsAddWatchModalOpen(false)}
                 title="Add Watch"
-                className="w-[750px]"
+                className="w-[800px]"
             >
                 <NoWatchesMessage hideTitle={true} />
             </Modal>


### PR DESCRIPTION
## Summary
- update `NoWatchesMessage` example and help text for the new `outrig` watch API
- clarify that push watches should reuse a pusher instance

## Testing
- `npm run lint`
