### PR TITLE
feat(nix): use fetchurl so sha256 of tar.gz can be compared

### DIFF
--- a/server/outrig-server.nix
+++ b/server/outrig-server.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchzip,
+  fetchurl,
 }:
 let
   system = lib.splitString "-" stdenv.hostPlatform.system;
@@ -29,9 +29,9 @@ in
   pname = "outrig";
   version = "0.8.2";
 
-  src = fetchzip {
+  src = fetchurl {
     url = "https://github.com/outrigdev/outrig/releases/download/v${version}/${pname}_${version}_${platform}_${arch}.tar.gz";
-    hash = hashes.${stdenv.hostPlatform.system};
+    sha256 = hashes.${stdenv.hostPlatform.system};
   };
 
   dontBuild = true;


### PR DESCRIPTION
`fetchzip` uses recursive hashing so can not be used for the purpose of comparing against the sha256 of the archive.