### PR TITLE
Add host config to monitor server

### DIFF
--- a/server/main-server.go
+++ b/server/main-server.go
@@ -180,12 +180,14 @@ func main() {
 			}
 
 			// Get the flag values
+			host, _ := cmd.Flags().GetString("host")
 			port, _ := cmd.Flags().GetInt("port")
 			closeOnStdin, _ := cmd.Flags().GetBool("close-on-stdin")
 			trayPid, _ := cmd.Flags().GetInt("tray-pid")
 
 			// Create CLI config
 			cfg := boot.CLIConfig{
+				Host:         host,
 				Port:         port,
 				CloseOnStdin: closeOnStdin,
 				TrayAppPid:   trayPid,
@@ -197,6 +199,7 @@ func main() {
 	// Add flags to monitor command
 	monitorCmd.Flags().Bool("no-telemetry", false, "Disable telemetry collection")
 	monitorCmd.Flags().Bool("no-updatecheck", false, "Disable checking for updates")
+	monitorCmd.Flags().String("host", "", "Override the default web server port (default: 0.0.0.0 for production, 127.0.0.1 for development)")
 	monitorCmd.Flags().Int("port", 0, "Override the default web server port (default: 5005 for production, 6005 for development)")
 	monitorCmd.Flags().Bool("close-on-stdin", false, "Shut down the server when stdin is closed")
 	monitorCmd.Flags().Int("tray-pid", 0, "PID of the tray application that started the server")

--- a/server/main-server.go
+++ b/server/main-server.go
@@ -6,8 +6,10 @@ package main
 import (
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	"github.com/outrigdev/outrig/pkg/config"
@@ -180,15 +182,25 @@ func main() {
 			}
 
 			// Get the flag values
-			host, _ := cmd.Flags().GetString("host")
-			port, _ := cmd.Flags().GetInt("port")
+			listenAddr, _ := cmd.Flags().GetString("listen")
 			closeOnStdin, _ := cmd.Flags().GetBool("close-on-stdin")
 			trayPid, _ := cmd.Flags().GetInt("tray-pid")
 
+			// Validate listen address if provided
+			if listenAddr != "" {
+				_, portStr, err := net.SplitHostPort(listenAddr)
+				if err != nil {
+					return fmt.Errorf("invalid listen address '%s': %w", listenAddr, err)
+				}
+				_, err = strconv.Atoi(portStr)
+				if err != nil {
+					return fmt.Errorf("invalid port in listen address '%s': %w", listenAddr, err)
+				}
+			}
+
 			// Create CLI config
 			cfg := boot.CLIConfig{
-				Host:         host,
-				Port:         port,
+				ListenAddr:   listenAddr,
 				CloseOnStdin: closeOnStdin,
 				TrayAppPid:   trayPid,
 			}
@@ -199,8 +211,7 @@ func main() {
 	// Add flags to monitor command
 	monitorCmd.Flags().Bool("no-telemetry", false, "Disable telemetry collection")
 	monitorCmd.Flags().Bool("no-updatecheck", false, "Disable checking for updates")
-	monitorCmd.Flags().String("host", "", "Override the default web server port (default: 0.0.0.0 for production, 127.0.0.1 for development)")
-	monitorCmd.Flags().Int("port", 0, "Override the default web server port (default: 5005 for production, 6005 for development)")
+	monitorCmd.Flags().String("listen", "", "Override the default web server listen address (default: 127.0.0.1:5005)")
 	monitorCmd.Flags().Bool("close-on-stdin", false, "Shut down the server when stdin is closed")
 	monitorCmd.Flags().Int("tray-pid", 0, "PID of the tray application that started the server")
 	// Hide this flag since it's only used internally by the tray application

--- a/server/pkg/boot/boot.go
+++ b/server/pkg/boot/boot.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"os/signal"
 	"strconv"
@@ -45,41 +46,52 @@ var (
 
 // CLIConfig holds configuration options passed from the command line
 type CLIConfig struct {
-	// Host overrides the default web server host if non-empty
-	Host string
-	// Port overrides the default web server port if non-zero
-	Port int
+	// ListenAddr overrides the default web server listen address
+	ListenAddr string
 	// CloseOnStdin indicates whether the server should shut down when stdin is closed
 	CloseOnStdin bool
 	// TrayAppPid is the PID of the tray application that started the server (0 if not from tray)
 	TrayAppPid int
 }
 
-// getWebServerHost determines the listen host for the web server
-func getWebServerHost(config CLIConfig) string {
-	// Determine web server host for listening
-	listenHost := serverbase.GetWebServerHost()
-	if config.Host != "" {
-		listenHost = config.Host
+// parseListenAddr parses a listen address string into host and port
+func parseListenAddr(addr string) (string, int, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid listen address format: %w", err)
 	}
-	return listenHost
+	
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid port number: %w", err)
+	}
+	
+	return host, port, nil
 }
 
-// getWebServerPorts determines the listen and advertise ports for the web server
-func getWebServerPorts(config CLIConfig) (int, int) {
-	// Determine web server port for listening
-	listenPort := serverbase.GetWebServerPort()
-	if config.Port > 0 {
-		listenPort = config.Port
+// getWebServerAddr determines the listen address for the web server
+func getWebServerAddr(config CLIConfig) (string, int) {
+	// Use override if provided
+	if config.ListenAddr != "" {
+		host, port, err := parseListenAddr(config.ListenAddr)
+		if err != nil {
+			log.Printf("Invalid listen address '%s', using default: %v", config.ListenAddr, err)
+		} else {
+			return host, port
+		}
 	}
+	
+	// Use serverbase defaults
+	return serverbase.GetWebServerHost(), serverbase.GetWebServerPort()
+}
 
-	// Determine the port to advertise to SDK clients
+// getAdvertisePort determines the port to advertise to SDK clients
+func getAdvertisePort(listenPort int) int {
 	advertisePort := listenPort
 	if serverbase.IsDev() {
 		advertisePort = 5173 // override to the vite port for SDK clients
 	}
-
-	return listenPort, advertisePort
+	return advertisePort
 }
 
 // RunServer initializes and runs the Outrig server
@@ -196,8 +208,8 @@ func RunServer(config CLIConfig) error {
 	updatecheck.StartUpdateChecker(config.TrayAppPid)
 
 	// Determine web server host and ports
-	listenHost := getWebServerHost(config)
-	listenPort, advertisePort := getWebServerPorts(config)
+	listenHost, listenPort := getWebServerAddr(config)
+	advertisePort := getAdvertisePort(listenPort)
 
 	// Create connection multiplexer
 	multiplexerAddr := listenHost + ":" + strconv.Itoa(listenPort)

--- a/server/pkg/serverbase/serverbase.go
+++ b/server/pkg/serverbase/serverbase.go
@@ -39,6 +39,12 @@ const OutrigDevEnvName = "OUTRIG_DEV"
 const OutrigTEventsFile = "tevents.jsonl"
 const AppcastURL = "https://updates.outrig.run/appcast.xml"
 
+// Default production host for server
+const ProdWebServerHost = "0.0.0.0"
+
+// Development host for server
+const DevWebServerHost = "127.0.0.1"
+
 // Default production port for server
 const ProdWebServerPort = 5005
 
@@ -65,6 +71,14 @@ func GetOutrigHome() string {
 // GetDomainSocketName returns the full domain socket path
 func GetDomainSocketName() string {
 	return GetOutrigHome() + config.DefaultDomainSocketName
+}
+
+// GetWebServerHost returns the appropriate web server host based on mode
+func GetWebServerHost() string {
+	if IsDev() {
+		return DevWebServerHost
+	}
+	return ProdWebServerHost
 }
 
 // GetWebServerPort returns the appropriate web server port based on mode

--- a/server/pkg/serverbase/serverbase.go
+++ b/server/pkg/serverbase/serverbase.go
@@ -40,7 +40,7 @@ const OutrigTEventsFile = "tevents.jsonl"
 const AppcastURL = "https://updates.outrig.run/appcast.xml"
 
 // Default host for monitor
-const WebServerHost = "127.0.0.1"
+const WebServerHost = "localhost"
 
 // Default production port for monitor
 const ProdWebServerPort = 5005

--- a/server/pkg/serverbase/serverbase.go
+++ b/server/pkg/serverbase/serverbase.go
@@ -39,16 +39,13 @@ const OutrigDevEnvName = "OUTRIG_DEV"
 const OutrigTEventsFile = "tevents.jsonl"
 const AppcastURL = "https://updates.outrig.run/appcast.xml"
 
-// Default production host for server
-const ProdWebServerHost = "0.0.0.0"
+// Default host for monitor
+const WebServerHost = "127.0.0.1"
 
-// Development host for server
-const DevWebServerHost = "127.0.0.1"
-
-// Default production port for server
+// Default production port for monitor
 const ProdWebServerPort = 5005
 
-// Development port for server
+// Development port for monitor
 const DevWebServerPort = 6005
 
 type FDLock interface {
@@ -75,10 +72,7 @@ func GetDomainSocketName() string {
 
 // GetWebServerHost returns the appropriate web server host based on mode
 func GetWebServerHost() string {
-	if IsDev() {
-		return DevWebServerHost
-	}
-	return ProdWebServerHost
+	return WebServerHost
 }
 
 // GetWebServerPort returns the appropriate web server port based on mode


### PR DESCRIPTION
The Monitor server currently runs on hardcoded 127.0.0.1. This prevents running in some conditions, like in a IPv6 only setup, or for example in Kubernetes with a Service and Ingress, which will send the traffic to the pod interface, resulting in a Bad Gateway.

I added a new Host config, which defaults to `0.0.0.0` for production and `127.0.0.1` for developement and is configurable via the `--host` CLI argument of the `monitor` command.

Acceptable values are those of [net.Listen](https://pkg.go.dev/net#Listen) and [net.Dial](https://pkg.go.dev/net#Dial) (`host` part only):
> For TCP and UDP networks, the address has the form "host:port". The host must be a literal IP address, or a host name that can be resolved to IP addresses. The port must be a literal port number or a service name. If the host is a literal IPv6 address it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80". The zone specifies the scope of the literal IPv6 address as defined in RFC 4007. The functions JoinHostPort and SplitHostPort manipulate a pair of host and port in this form. When using TCP, and the host resolves to multiple IP addresses, Dial will try each IP address in order until one succeeds.
>
> Examples:
>
> Dial("tcp", "golang.org:http")
> Dial("tcp", "192.0.2.1:http")
> Dial("tcp", "198.51.100.1:80")
> Dial("udp", "[2001:db8::1]:domain")
> Dial("udp", "[fe80::1%lo0]:53")
> Dial("tcp", ":80")

In the mean time, I published [a release](https://github.com/alexandregv/outrig/releases/tag/v0.9.0-1-24c92bf) on my fork to use this version easily.

Official installation script can be hot-patched like so:
```bash
curl -sf https://outrig.run/install.sh | sed 's#github.com/outrigdev/outrig#github.com/alexandregv/outrig#g' | OUTRIG_VERSION="0.9.0-1-24c92bf" sh
```